### PR TITLE
[refactor] Allow other packages depend on Config without depending on the bot

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/DzyubSpirit/reTGanslatorBot/bot"
+	"github.com/DzyubSpirit/reTGanslatorBot/config"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("Failed to read config.json: %v", err)
 	}
 
-	var config bot.Config
+	var config config.Config
 	if err = json.Unmarshal(configBytes, &config); err != nil {
 		log.Fatalf("Failed to parse config.json: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"sort"
+	"strings"
+)
+
+type Config struct {
+	Chats        []Chat   `json:"chats"`
+	HelpContacts []string `json:"help_contacts"`
+}
+
+type Chat struct {
+	ID         int64    `json:"id"`
+	Aliases    []string `json:"aliases"`
+	ChildChats []Chat   `json:"child_chats"`
+}
+
+func (config Config) AllAliases() []string {
+	aliases := make(map[string]bool)
+	queue := config.Chats
+	for len(queue) > 0 {
+		chat := queue[0]
+		queue = queue[1:]
+
+		for _, alias := range chat.Aliases {
+			aliases[alias] = true
+		}
+		queue = append(queue, chat.ChildChats...)
+	}
+	var aliasesList []string
+	for alias := range aliases {
+		aliasesList = append(aliasesList, alias)
+	}
+	sort.Slice(aliasesList, func(i, j int) bool {
+		return strings.ToLower(aliasesList[i]) < strings.ToLower(aliasesList[j])
+	})
+	return aliasesList
+}
+
+func (config Config) AllChats() []Chat {
+	var allChats []Chat
+	queue := config.Chats
+	for len(queue) > 0 {
+		chat := queue[0]
+		queue = queue[1:]
+
+		allChats = append(allChats, chat)
+		queue = append(queue, chat.ChildChats...)
+	}
+	return allChats
+}

--- a/webhook.go
+++ b/webhook.go
@@ -9,6 +9,7 @@ import (
 	urlpath "path"
 
 	"github.com/DzyubSpirit/reTGanslatorBot/bot"
+	"github.com/DzyubSpirit/reTGanslatorBot/config"
 	_ "github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
@@ -50,7 +51,7 @@ func NewServerFromEnv() *Server {
 		log.Fatalf("Failed to read config.json: %v", err)
 	}
 
-	var config bot.Config
+	var config config.Config
 	if err = json.Unmarshal(configBytes, &config); err != nil {
 		log.Fatalf("Failed to parse config.json: %v", err)
 	}


### PR DESCRIPTION
There is a FR upcoming which will use Telegram API (not Telegram Bot
API) which will rely on the config and the chat structure